### PR TITLE
more color contrast in table

### DIFF
--- a/template.html
+++ b/template.html
@@ -45,9 +45,9 @@
                         <th scope="row">{{row.package_name}}</th>
                         {{#each row.availability_list as |status|}}
                         {{#if status}}
-                        <td class="table-success text-center">present</td>
+                        <td class="table-primary text-center">present</td>
                         {{else}}
-                        <td class="table-danger text-center">missing</td>
+                        <td class="table-warning text-center">missing</td>
                         {{/if}}
                         {{/each}}
                         {{#if row.last_available}}


### PR DESCRIPTION
I love the site, very useful thanks! However, I'm colorblind and find the current colors a little too low contrast to see well. I ran a screenshot through a colorblindness simulator which might help illustrate the problem:

**As-is**:

![image](https://user-images.githubusercontent.com/7574/58375887-6f013600-7f12-11e9-9c6d-09b1f7b73088.png)

**Simulated Green-Weak/Deuteranomaly** using [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/):

![image](https://user-images.githubusercontent.com/7574/58375902-9fe16b00-7f12-11e9-9b9a-be55323f6b1e.png)

So I tried swapping out a few of the bootstrap styles to see if there was something that had better contrast. The blue and yellow combination of `table-primary` and `table-warning` works great for me and seems to look well-contrasted according to the simulators on [Coblis](https://www.color-blindness.com/coblis-color-blindness-simulator/). This is what it looks like (no colorblindness simulated):

![image](https://user-images.githubusercontent.com/7574/58375883-5729b200-7f12-11e9-8bca-1115eb30fad5.png)

What do you think? This seems a little more accessible and still illustrates the difference well.

I **do** really appreciate that you don't just use color to indicate present/missing but have text as well. That's great for accessibility! This would make things just a little bit nicer ;).
