### PR TITLE
illumos is now a Tier 2 platform

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,7 @@ tiers:
     - "x86_64-unknown-cloudabi"
     - "x86_64-unknown-freebsd"
     - "x86_64-unknown-fuchsia"
+    - "x86_64-unknown-illumos"
     - "x86_64-unknown-linux-gnux32"
     - "x86_64-unknown-linux-musl"
     - "x86_64-unknown-netbsd"

--- a/web/src/opts.rs
+++ b/web/src/opts.rs
@@ -158,6 +158,7 @@ tiers:
     - "x86_64-unknown-cloudabi"
     - "x86_64-unknown-freebsd"
     - "x86_64-unknown-fuchsia"
+    - "x86_64-unknown-illumos"
     - "x86_64-unknown-linux-gnux32"
     - "x86_64-unknown-linux-musl"
     - "x86_64-unknown-netbsd"
@@ -226,7 +227,7 @@ mod test {
         );
         assert_eq!(Some(7), defaults.html.tiers.get(&Tier::Tier1).map(Vec::len));
         assert_eq!(
-            Some(46),
+            Some(47),
             defaults.html.tiers.get(&Tier::Tier2).map(Vec::len)
         );
         assert_eq!(


### PR DESCRIPTION
With the integration of rust-lang/rust#71272, illumos is now (as I understand it!) a Tier 2 platform (see also rust-lang/compiler-team#279).  We have target and host binaries being built through CI/CD, which you can see at: https://rust-lang.github.io/rustup-components-history/x86_64-unknown-illumos.html

This change moves us into the Tier 2 box.  Passes `cargo test` on my build system.