### PR TITLE
aarch64-pc-windows-msvc is now a Tier 2 platform

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,7 @@ tiers:
   Tier2:
     - "aarch64-apple-ios"
     - "aarch64-linux-android"
+    - "aarch64-pc-windows-msvc"
     - "aarch64-unknown-fuchsia"
     - "aarch64-unknown-linux-gnu"
     - "aarch64-unknown-linux-musl"

--- a/web/src/opts.rs
+++ b/web/src/opts.rs
@@ -118,6 +118,7 @@ tiers:
   Tier2:
     - "aarch64-apple-ios"
     - "aarch64-linux-android"
+    - "aarch64-pc-windows-msvc"
     - "aarch64-unknown-fuchsia"
     - "aarch64-unknown-linux-gnu"
     - "aarch64-unknown-linux-musl"
@@ -227,7 +228,7 @@ mod test {
         );
         assert_eq!(Some(7), defaults.html.tiers.get(&Tier::Tier1).map(Vec::len));
         assert_eq!(
-            Some(47),
+            Some(48),
             defaults.html.tiers.get(&Tier::Tier2).map(Vec::len)
         );
         assert_eq!(


### PR DESCRIPTION
`aarch64-pc-windows-msvc` has been promoted to Tier 2 Development Platform recently: https://github.com/rust-lang/rust/pull/75914
This means both std and host tools are now being built: https://rust-lang.github.io/rustup-components-history/aarch64-pc-windows-msvc.html
This PR adds it to the list of Tier 2 platform. `cargo +stable-i686-pc-windows-msvc test` succeeds! (doesn't build on aarch64 yet 😅)