### PR TITLE
Change authors to "The Rustup Compoments History Developers"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-available-packages"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "log",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-available-packages-web"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustup-available-packages"
-version = "0.2.1"
-authors = ["mexus <gilaldpellaeon@gmail.com>"]
+version = "0.2.2"
+authors = ["The Rustup Compoments History Developers"]
 description = "Rustup tools state info"
 license = "MIT/Apache-2.0"
 keywords = ["rustup"]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustup-available-packages-web"
-version = "0.1.3"
-authors = ["mexus <gilaldpellaeon@gmail.com>"]
+version = "0.1.4"
+authors = ["The Rustup Compoments History Developers"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
I think it's not fair that I'm the only person mentioned in `authors` of repo's crates since so many people have contributes to the project! So I propose to change the respective fields to
```toml
authors = ["The Rustup Compoments History Developers"]
```

I'm currently adding only @pietroalbini (hope I don't bother you with this too much!) as a reviewer, but please feel free to add anybody else you want to see in that role! Well, anyhow I'm not quite sure who's review should I ask for.. :)