### PR TITLE
run the update after the release process is most likely done

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    # Runs at 00:10 UTC every day. 
-    - cron: '10 0 * * *'
+    # Runs at 2:00 UTC every day (to give the release process 2h to complete).
+    - cron: '0 2 * * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I was once told (by @pietroalbini IIRC) that releasing can take an hour or more, so running at 2am UTC is probably better than running at 0:10 am UTC.

Fixes https://github.com/rust-lang/rustup-components-history/issues/37