### PR TITLE
Move 'Last available' column to left.

### DIFF
--- a/template.html
+++ b/template.html
@@ -33,16 +33,21 @@
             <table class="table table-hover table-bordered table-responsive-lg table-sm">
                 <thead>
                     <tr>
-                    {{#each title as |t|}}
+                        <th scope="col" class="text-center"></th>
+                        {{#each title as |t|}}
                         <th scope="col" class="text-center">{{t}}</th>
-                    {{/each}}
-                        <th scope="col" class="text-center">Last available</th>
+                        {{/each}}
                     </tr>
                 </thead>
                 <tbody>
                     {{#each packages_availability as |row|}}
                     <tr>
                         <th scope="row">{{row.package_name}}</th>
+                        {{#if row.last_available}}
+                        <td class="text-center">{{row.last_available}}</td>
+                        {{else}}
+                        <td class="text-center">N/A</td>
+                        {{/if}}
                         {{#each row.availability_list as |status|}}
                         {{#if status}}
                         <td class="table-primary text-center">present</td>
@@ -50,11 +55,6 @@
                         <td class="table-warning text-center">missing</td>
                         {{/if}}
                         {{/each}}
-                        {{#if row.last_available}}
-                        <td class="text-center">{{row.last_available}}</td>
-                        {{else}}
-                        <td class="text-center">N/A</td>
-                        {{/if}}
                     </tr>
                     {{/each}}
                 </tbody>

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -90,6 +90,7 @@ fn generate_html(
             .with_context(|| format!("Can't create file [{}]", output_path))?;
 
         let table = Table::builder(&data, target)
+            .first_cell(&"Last available")
             .dates(dates)
             .additional(&additional)
             .build();


### PR DESCRIPTION
When it was on the right, it made it seem like the table should be read
right-to-left, i.e. the column on the right is the newest. When in
reality the column on the left is the newest and most important.