### PR TITLE
Fix gh-actions trying to deploy PRs, allow manual trigger, use gh-actions account for auto commit.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,13 +31,12 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         git worktree add gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
         cd gh-pages
         # Delete the ref to avoid keeping history.
         git update-ref -d refs/heads/gh-pages
         rm -rf *
         mv ../output/* .
         git add .
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
+        git -c 'user.name=github-actions[bot]' -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
+          commit -m "Deploy $GITHUB_SHA to gh-pages"
         git push --force

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,8 @@
 name: Rust
 
 on:
-  push: 
+  workflow_dispatch:
+  push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
@@ -21,9 +22,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     - name: Prepare pages
       run: ./prepare-pages.sh
+
     - name: Deploy GitHub Pages
+      # Do not deploy PRs.
+      if: ${{ github.event_name != 'pull_request' }}
       run: |
         git worktree add gh-pages gh-pages
         git config user.name "Deploy from CI"


### PR DESCRIPTION
Prevents gh-actions from trying to deploy PRs which causes the action to fail w/ 403 (https://github.com/rust-lang/rustup-components-history/pull/41/checks?check_run_id=3625482069)

Adds manual trigger which repo admin can use to run an update if needed.

Use gh-actions account for the gh-pages commit, makes the repo UI a bit nicer rather than showing a blank "Deploy from CI" user.