### PR TITLE
remove `rls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Machine-readable information on the latest availability can be fetched on a
 *per-component-per-target* basis, i.e.
 `https://rust-lang.github.io/rustup-components-history/$target/$package` where `$target` stands for
 a target host architecture, like `x86_64-unknown-linux-gnu`, and `$package` stands for a package
-name, like `rls` or `rust-src`. For example, getting the date when `miri` was available for the last
+name, like `miri` or `rust-src`. For example, getting the date when `miri` was available for the last
 time on `x86_64-apple-darwin` is as simple as running the following command:
 
 ```

--- a/library/src/manifest.rs
+++ b/library/src/manifest.rs
@@ -97,9 +97,6 @@ available = false
 [pkg.rustfmt-preview.target.x86_64-unknown-linux-gnu]
 available = true
 
-[renames.rls]
-to = "rls-preview"
-
 [renames.rustfmt]
 to = "rustfmt-preview"
 "#;
@@ -153,12 +150,6 @@ to = "rustfmt-preview"
             .into_iter()
             .collect(),
             renames: vec![
-                (
-                    "rls".to_string(),
-                    Rename {
-                        to: "rls-preview".to_string(),
-                    },
-                ),
                 (
                     "rustfmt".to_string(),
                     Rename {

--- a/web/src/opts.rs
+++ b/web/src/opts.rs
@@ -72,7 +72,7 @@ pub struct Config {
     /// will generate a set of files under a given *output* directory with the
     /// following pattern: file_tree_output/$target/$package, where $target
     /// stands for a target host architecture, like x86_64-unknown-linux-gnu,
-    /// and $package stands for a package name, like rls or rust-src. Each of
+    /// and $package stands for a package name, like miri or rust-src. Each of
     /// those files will contain a date in a "%Y-%m-%d" format (e.g. 2019-12-24)
     /// which represents the latest date when the package was (is) available for
     /// that specific target.


### PR DESCRIPTION
We started removing `rls` completely from the toolchain and this PR removes `rls` specific parts from this repository.

Blocked by https://github.com/rust-lang/rustup/pull/3920 and https://github.com/rust-lang/rust/pull/126856.

Zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/excluding.20rls.20from.20the.20release