### PR TITLE
library: Deserialize version and git commit hash from the rustup TOML manifests

### DIFF
--- a/library/src/availability.rs
+++ b/library/src/availability.rs
@@ -139,8 +139,14 @@ mod tests {
     #[test]
     fn check() {
         let data = r#"date = "2018-09-03"
+[pkg.rust-src]
+version = "0.0.0"
+git_commit_hash = "0123456789abcdef"
 [pkg.rust-src.target."*"]
 available = true
+[pkg.ahaha]
+version = "0.0.0"
+git_commit_hash = "0123456789abcdef"
 [pkg.ahaha.target.lol]
 available = true
 "#;
@@ -179,6 +185,9 @@ available = true
     #[test]
     fn check_rename() {
         let data = r#"date = "2018-09-03"
+[pkg.ahaha]
+version = "0.0.0"
+git_commit_hash = "0123456789abcdef"
 [pkg.ahaha.target.lol]
 available = true
 [renames.kek]

--- a/library/src/manifest.rs
+++ b/library/src/manifest.rs
@@ -83,6 +83,9 @@ mod tests {
     #[test]
     fn check() {
         let data = r#"date = "2018-09-03"
+[pkg.cargo]
+version = "0.89.0-nightly (7918c7eb5 2025-04-27)"
+git_commit_hash = "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d"
 [pkg.cargo.target.aarch64-unknown-linux-gnu]
 available = true
 
@@ -91,6 +94,10 @@ available = true
 
 [pkg.cargo.target.arm-unknown-linux-gnueabihf]
 available = false
+
+[pkg.rustfmt-preview]
+version = "1.8.0-nightly"
+git_commit_hash = "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d"
 
 [pkg.rustfmt-preview.target.aarch64-unknown-linux-gnu]
 available = true
@@ -114,6 +121,8 @@ to = "rustfmt-preview"
                 (
                     "cargo".to_string(),
                     PackageTargets {
+                        version: "0.89.0-nightly (7918c7eb5 2025-04-27)".to_string(),
+                        git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
                         targets: vec![
                             (
                                 "aarch64-unknown-linux-gnu".to_string(),
@@ -135,6 +144,8 @@ to = "rustfmt-preview"
                 (
                     "rustfmt-preview".to_string(),
                     PackageTargets {
+                        version: "1.8.0-nightly".to_string(),
+                        git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
                         targets: vec![
                             (
                                 "aarch64-unknown-linux-gnu".to_string(),
@@ -179,6 +190,9 @@ to = "rustfmt-preview"
     #[test]
     fn check_wildcard() {
         let data = r#"date = "2018-09-03"
+[pkg.rust-src]
+version = "1.88.0-nightly (e9f8103f9 2025-05-07)"
+git_commit_hash = "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d"
 [pkg.rust-src.target."*"]
 available = true
 url = "https://static.rust-lang.org/dist/2018-09-03/rust-src-nightly.tar.gz"
@@ -192,6 +206,8 @@ xz_hash = "dbb913da0a207ae80c53bc6a42074b637920c2a80121420416579fed3e7f2499"
             packages: vec![(
                 "rust-src".to_string(),
                 PackageTargets {
+                    version: "1.88.0-nightly (e9f8103f9 2025-05-07)".to_string(),
+                    git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
                     targets: vec![("*".to_string(), PackageInfo { available: true })]
                         .into_iter()
                         .collect(),
@@ -210,6 +226,7 @@ xz_hash = "dbb913da0a207ae80c53bc6a42074b637920c2a80121420416579fed3e7f2499"
 date = "2018-09-03"
 [pkg.cargo]
 version = "0.30.0-nightly (0ec7281b9 2018-08-20)"
+git_commit_hash = "0ec7281b9c3f8e2fa2c15c0c6796ec821f8ae15d"
 [pkg.cargo.target.aarch64-unknown-linux-gnu]
 available = true
 url = "https://static.rust-lang.org/dist/2018-09-04/cargo-nightly-aarch64-unknown-linux-gnu.tar.gz"
@@ -233,6 +250,7 @@ xz_hash = "ca0e68e7e9827ba6221a40bb17170e8dc6271a9f6991ee5030dcf6acb1a1d8c8"
 
 [pkg.rustfmt-preview]
 version = "0.99.2-nightly (5c9a2b6c1 2018-08-07)"
+git_commit_hash = "0ec7281b9c3f8e2fa2c15c0c6796ec821f8ae15d"
 [pkg.rustfmt-preview.target.aarch64-unknown-linux-gnu]
 available = true
 url = "https://static.rust-lang.org/dist/2018-09-03/rustfmt-nightly-aarch64-unknown-linux-gnu.tar.gz"

--- a/library/src/manifest.rs
+++ b/library/src/manifest.rs
@@ -40,6 +40,7 @@ pub struct PackageTargets {
     /// The package version. May be empty if the package is not available.
     pub version: String,
     /// The commit hash of the package. May be `None` if the package is not available.
+    #[serde(default)]
     pub git_commit_hash: Option<String>,
     /// Maps targets onto package availability info.
     #[serde(rename = "target")]
@@ -122,7 +123,9 @@ to = "rustfmt-preview"
                     "cargo".to_string(),
                     PackageTargets {
                         version: "0.89.0-nightly (7918c7eb5 2025-04-27)".to_string(),
-                        git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
+                        git_commit_hash: Some(
+                            "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
+                        ),
                         targets: vec![
                             (
                                 "aarch64-unknown-linux-gnu".to_string(),
@@ -145,7 +148,9 @@ to = "rustfmt-preview"
                     "rustfmt-preview".to_string(),
                     PackageTargets {
                         version: "1.8.0-nightly".to_string(),
-                        git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
+                        git_commit_hash: Some(
+                            "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
+                        ),
                         targets: vec![
                             (
                                 "aarch64-unknown-linux-gnu".to_string(),
@@ -207,7 +212,7 @@ xz_hash = "dbb913da0a207ae80c53bc6a42074b637920c2a80121420416579fed3e7f2499"
                 "rust-src".to_string(),
                 PackageTargets {
                     version: "1.88.0-nightly (e9f8103f9 2025-05-07)".to_string(),
-                    git_commit_hash: "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string(),
+                    git_commit_hash: Some("e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d".to_string()),
                     targets: vec![("*".to_string(), PackageInfo { available: true })]
                         .into_iter()
                         .collect(),

--- a/library/src/manifest.rs
+++ b/library/src/manifest.rs
@@ -37,6 +37,10 @@ pub struct Rename {
 /// Package info.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PackageTargets {
+    /// The package version
+    pub version: String,
+    /// The commit hash of the package
+    pub git_commit_hash: String,
     /// Maps targets onto package availability info.
     #[serde(rename = "target")]
     pub targets: HashMap<String, PackageInfo>,

--- a/library/src/manifest.rs
+++ b/library/src/manifest.rs
@@ -37,10 +37,10 @@ pub struct Rename {
 /// Package info.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PackageTargets {
-    /// The package version
+    /// The package version. May be empty if the package is not available.
     pub version: String,
-    /// The commit hash of the package
-    pub git_commit_hash: String,
+    /// The commit hash of the package. May be `None` if the package is not available.
+    pub git_commit_hash: Option<String>,
     /// Maps targets onto package availability info.
     #[serde(rename = "target")]
     pub targets: HashMap<String, PackageInfo>,


### PR DESCRIPTION
The TOML manifest has these fields,  but the `PackageTargets` type does not deserialize them:

```toml
[pkg.rust]
version = "1.88.0-nightly (e9f8103f9 2025-05-07)"
git_commit_hash = "e9f8103f93f8ce2fa2c15c0c6796ec821f8ae15d"
```

```rust
/// Package info.
#[derive(Debug, Serialize, Deserialize, PartialEq)]
pub struct PackageTargets {
    /// Maps targets onto package availability info.
    #[serde(rename = "target")]
    pub targets: HashMap<String, PackageInfo>,
}
```

This PR updates `PackageTargets` to include the `version` and `git_commit_hash` fields

Fixes #58 